### PR TITLE
feat: implement caching for GitHub API responses

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -33,7 +33,10 @@ export async function GET(request: Request) {
       })
     );
 
-    return NextResponse.json({ success: true, users: results });
+    return NextResponse.json(
+      { success: true, users: results },
+      { headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60" } }
+    );
   } catch (error: any) {
     console.error("GitHub score error:", error);
     const message =

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,35 @@
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+const store = new Map<string, CacheEntry<unknown>>();
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+export function getCached<T>(key: string): T | undefined {
+  const entry = store.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    store.delete(key);
+    return undefined;
+  }
+  return entry.data as T;
+}
+
+export function setCached<T>(key: string, data: T, ttlMs = DEFAULT_TTL_MS) {
+  store.set(key, { data, expiresAt: Date.now() + ttlMs });
+}
+
+export function cacheStats() {
+  let valid = 0;
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    if (now > entry.expiresAt) {
+      store.delete(key);
+    } else {
+      valid++;
+    }
+  }
+  return { size: valid };
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,5 +1,6 @@
 import { ContributionTotals, GitHubUserData, PullRequestNode, RepoNode } from "@/types/github";
 import { graphql } from "@octokit/graphql";
+import { getCached, setCached } from "./cache";
 
 if (!process.env.GITHUB_TOKEN) {
   throw new Error("Missing GITHUB_TOKEN");
@@ -60,15 +61,22 @@ const QUERY = /* GraphQL */ `
 export async function fetchGitHubUserData(
   username: string
 ): Promise<GitHubUserData> {
+  const cacheKey = `github:${username.toLowerCase()}`;
+  const cached = getCached<GitHubUserData>(cacheKey);
+  if (cached) return cached;
+
   const { user } = await client<{ user: any }>(QUERY, { login: username });
 
   if (!user) {
     throw new Error("User not found");
   }
 
-  return {
+  const data: GitHubUserData = {
     repos: user.repositories.nodes as RepoNode[],
     pullRequests: user.pullRequests.nodes as PullRequestNode[],
     contributions: user.contributionsCollection as ContributionTotals,
   };
+
+  setCached(cacheKey, data);
+  return data;
 }


### PR DESCRIPTION
## Summary
Closes #33

Adds in-memory caching for GitHub GraphQL API responses to reduce redundant API calls and improve response times.

### Changes
- **`lib/cache.ts`** — Generic cache with TTL-based expiration (default 5 min). Entries auto-expire on read.
- **`lib/github.ts`** — `fetchGitHubUserData` checks cache before calling GitHub API. Cache key is the lowercased username.
- **`app/api/compare/route.ts`** — Adds `Cache-Control: public, s-maxage=300, stale-while-revalidate=60` header for CDN/browser caching.

### How it works
1. First request for a username → hits GitHub API, stores result in cache
2. Subsequent requests within 5 minutes → served from cache (no API call)
3. After TTL expires → next request fetches fresh data

### Benefits
- Reduces GitHub API rate limit consumption
- Faster responses for repeated comparisons
- Zero external dependencies (in-memory Map)

## Test plan
- [ ] Compare same usernames twice — second request should be noticeably faster
- [ ] Wait 5+ minutes and compare again — should fetch fresh data
- [ ] Check response headers include Cache-Control