### PR TITLE
feat: handle GitHub API rate limits gracefully

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -33,7 +33,10 @@ export async function GET(request: Request) {
       })
     );
 
-    return NextResponse.json({ success: true, users: results });
+    return NextResponse.json(
+      { success: true, users: results },
+      { headers: { "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60" } }
+    );
   } catch (error: any) {
     console.error("GitHub score error:", error);
     const message =

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { fetchGitHubUserData } from "../../../lib/github";
+import { fetchGitHubUserData, RateLimitError } from "../../../lib/github";
 import { calculateUserScore } from "../../../lib/score";
 
 export const runtime = "nodejs";
@@ -39,6 +39,21 @@ export async function GET(request: Request) {
     );
   } catch (error: any) {
     console.error("GitHub score error:", error);
+
+    if (error instanceof RateLimitError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "GitHub API rate limit exceeded. Please try again later.",
+          retryAfter: error.retryAfter,
+        },
+        {
+          status: 429,
+          headers: { "Retry-After": String(error.retryAfter) },
+        }
+      );
+    }
+
     const message =
       error?.message === "User not found"
         ? "GitHub user not found"

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -17,6 +17,12 @@ export function getCached<T>(key: string): T | undefined {
   return entry.data as T;
 }
 
+export function getStale<T>(key: string): T | undefined {
+  const entry = store.get(key);
+  if (!entry) return undefined;
+  return entry.data as T;
+}
+
 export function setCached<T>(key: string, data: T, ttlMs = DEFAULT_TTL_MS) {
   store.set(key, { data, expiresAt: Date.now() + ttlMs });
 }

--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,35 @@
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+const store = new Map<string, CacheEntry<unknown>>();
+
+const DEFAULT_TTL_MS = 5 * 60 * 1000;
+
+export function getCached<T>(key: string): T | undefined {
+  const entry = store.get(key);
+  if (!entry) return undefined;
+  if (Date.now() > entry.expiresAt) {
+    store.delete(key);
+    return undefined;
+  }
+  return entry.data as T;
+}
+
+export function setCached<T>(key: string, data: T, ttlMs = DEFAULT_TTL_MS) {
+  store.set(key, { data, expiresAt: Date.now() + ttlMs });
+}
+
+export function cacheStats() {
+  let valid = 0;
+  const now = Date.now();
+  for (const [key, entry] of store) {
+    if (now > entry.expiresAt) {
+      store.delete(key);
+    } else {
+      valid++;
+    }
+  }
+  return { size: valid };
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,5 +1,6 @@
 import { ContributionTotals, GitHubUserData, PullRequestNode, RepoNode } from "@/types/github";
 import { graphql } from "@octokit/graphql";
+import { getCached, setCached } from "./cache";
 
 if (!process.env.GITHUB_TOKEN) {
   throw new Error("Missing GITHUB_TOKEN");
@@ -60,15 +61,22 @@ const QUERY = /* GraphQL */ `
 export async function fetchGitHubUserData(
   username: string
 ): Promise<GitHubUserData> {
+  const cacheKey = `github:${username.toLowerCase()}`;
+  const cached = getCached<GitHubUserData>(cacheKey);
+  if (cached) return cached;
+
   const { user } = await client<{ user: any }>(QUERY, { login: username });
 
   if (!user) {
     throw new Error("User not found");
   }
 
-  return {
+  const data: GitHubUserData = {
     repos: user.repositories.nodes as RepoNode[],
     pullRequests: user.pullRequests.nodes as PullRequestNode[],
     contributions: user.contributionsCollection as ContributionTotals,
   };
+
+  setCached(cacheKey, data);
+  return data;
 }

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,6 +1,6 @@
 import { ContributionTotals, GitHubUserData, PullRequestNode, RepoNode } from "@/types/github";
 import { graphql } from "@octokit/graphql";
-import { getCached, setCached } from "./cache";
+import { getCached, getStale, setCached } from "./cache";
 
 if (!process.env.GITHUB_TOKEN) {
   throw new Error("Missing GITHUB_TOKEN");
@@ -58,6 +58,20 @@ const QUERY = /* GraphQL */ `
   }
 `;
 
+export class RateLimitError extends Error {
+  retryAfter: number;
+  constructor(retryAfter: number) {
+    super("GitHub API rate limit exceeded");
+    this.name = "RateLimitError";
+    this.retryAfter = retryAfter;
+  }
+}
+
+function isRateLimitError(error: any): boolean {
+  const status = error?.status ?? error?.response?.status;
+  return status === 403 || status === 429;
+}
+
 export async function fetchGitHubUserData(
   username: string
 ): Promise<GitHubUserData> {
@@ -65,18 +79,32 @@ export async function fetchGitHubUserData(
   const cached = getCached<GitHubUserData>(cacheKey);
   if (cached) return cached;
 
-  const { user } = await client<{ user: any }>(QUERY, { login: username });
+  try {
+    const { user } = await client<{ user: any }>(QUERY, { login: username });
 
-  if (!user) {
-    throw new Error("User not found");
+    if (!user) {
+      throw new Error("User not found");
+    }
+
+    const data: GitHubUserData = {
+      repos: user.repositories.nodes as RepoNode[],
+      pullRequests: user.pullRequests.nodes as PullRequestNode[],
+      contributions: user.contributionsCollection as ContributionTotals,
+    };
+
+    setCached(cacheKey, data);
+    return data;
+  } catch (error: any) {
+    if (isRateLimitError(error)) {
+      const stale = getStale<GitHubUserData>(cacheKey);
+      if (stale) return stale;
+
+      const resetAt = error.response?.headers?.["x-ratelimit-reset"];
+      const retryAfter = resetAt
+        ? Math.max(0, Number(resetAt) - Math.floor(Date.now() / 1000))
+        : 60;
+      throw new RateLimitError(retryAfter);
+    }
+    throw error;
   }
-
-  const data: GitHubUserData = {
-    repos: user.repositories.nodes as RepoNode[],
-    pullRequests: user.pullRequests.nodes as PullRequestNode[],
-    contributions: user.contributionsCollection as ContributionTotals,
-  };
-
-  setCached(cacheKey, data);
-  return data;
 }


### PR DESCRIPTION
## Summary
Closes #32

Gracefully handles GitHub API rate limit errors (403/429) with fallback to stale cached data and user-friendly error responses.

### Changes
- **`lib/cache.ts`** — Add `getStale()` to retrieve expired cache entries as fallback
- **`lib/github.ts`** — Catch rate limit errors, serve stale data when available, throw `RateLimitError` otherwise
- **`app/api/compare/route.ts`** — Return 429 status with `Retry-After` header and friendly message

### How it works
1. GitHub returns 403/429 → check for stale cached data for that username
2. Stale data found → return it transparently (users still get results)
3. No stale data → return 429 with `retryAfter` seconds until reset

### Note
Builds on the caching foundation from #33 (PR #39).

## Test plan
- [ ] Normal requests work unchanged
- [ ] When rate limited with prior cached data, stale results are served
- [ ] When rate limited without cache, 429 response includes retryAfter