### PR TITLE
fix: improve README grammar and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Factors include:
 Measures contributions to **other developers' repositories**.
 
 ✔ Only merged PRs are counted
-✔ PRs to user's own repositories are excluded
+✔ PRs to the user's own repositories are excluded
 
 Factors include:
 
@@ -90,7 +90,7 @@ Final Score =
 0.10 × Contribution Score
 ```
 
-👉 ContributionScore is capped to prevent abuse.
+👉 The ContributionScore is capped to prevent abuse.
 
 ---
 
@@ -123,7 +123,7 @@ Final Score =
 * Tailwind CSS
 * Recharts
 
-### Api
+### API
 
 * Node.js + Express
 * GitHub GraphQL API
@@ -139,8 +139,8 @@ Final Score =
 ### 1. Clone the repo
 
 ```bash
-git clone https://github.com/your-username/devimpact.git
-cd devimpact
+git clone https://github.com/O2sa/DevImpact.git
+cd DevImpact
 ```
 
 ---
@@ -153,7 +153,7 @@ pnpm install
 
 ---
 
-### 3. Setup environment variables
+### 3. Set up environment variables
 
 Create a `.env` file:
 


### PR DESCRIPTION
Closes #31

## Changes

- Fix `Api` → `API` in the Tech Stack section
- Fix clone URL to use the correct repository path (`O2sa/DevImpact`)
- Improve article usage: "the user's own repositories", "The ContributionScore"
- Fix verb form: `Setup` → `Set up` in Getting Started heading

/attempt 31