### PR TITLE
feat: setup ESLint flat config for consistent code style

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,30 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "no-unused-vars": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_" },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "no-console": ["warn", { allow: ["warn", "error"] }],
+      "prefer-const": "error",
+      "no-var": "error",
+      eqeqeq: ["error", "always"],
+    },
+  },
+];
+
+export default eslintConfig;


### PR DESCRIPTION
## Summary

Adds an ESLint flat config (`eslint.config.mjs`) that extends `next/core-web-vitals` and `next/typescript` with additional rules for code consistency:

- Warns on unused variables (ignoring `_` prefixed)
- Warns on `@typescript-eslint/no-explicit-any`
- Warns on `console.log` (allows `console.warn` and `console.error`)
- Enforces `prefer-const`, `no-var`, and strict equality (`eqeqeq`)

Closes #28

## Test Plan

- [ ] Run `pnpm lint` to verify ESLint picks up the new config
- [ ] Confirm no breaking lint errors on existing codebase