### PR TITLE
feat: add Prettier for consistent code formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+.next
+out
+build
+coverage
+pnpm-lock.yaml

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "printWidth": 80,
+  "bracketSpacing": true,
+  "arrowParens": "always",
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-tailwindcss"]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@octokit/graphql": "^9.0.3",
@@ -30,6 +32,8 @@
     "eslint-config-next": "^16.2.2",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
+    "prettier": "^3.4.2",
+    "prettier-plugin-tailwindcss": "^0.6.11",
     "typescript": "^6.0.2"
   }
 }


### PR DESCRIPTION
## Summary

Adds Prettier configuration for consistent code formatting across the project:

- `.prettierrc` with sensible defaults (2-space indent, semicolons, double quotes, trailing commas)
- Includes `prettier-plugin-tailwindcss` for automatic Tailwind class sorting
- `.prettierignore` to skip build artifacts and lock files
- `format` and `format:check` npm scripts for easy usage

Closes #27

## Test Plan

- [ ] Run `pnpm install` to install Prettier
- [ ] Run `pnpm format:check` to verify config is picked up
- [ ] Run `pnpm format` to format the codebase