### PR TITLE
feat: add copy result button with clipboard support (closes #35)

### DIFF
--- a/components/result-dashboard.tsx
+++ b/components/result-dashboard.tsx
@@ -1,11 +1,15 @@
+"use client";
+
+import { useState } from "react";
 import { ComparisonTable } from "./comparison-table";
 import { ComparisonChart } from "./comparison-chart";
 import { BreakdownBars } from "./breakdown-bars";
 import { TopList } from "./top-list";
 import { InsightsList } from "./insights-list";
 import { ScoreCard } from "./score-card";
+import { Button } from "./ui/button";
 import { Card, CardContent } from "./ui/card";
-import { Trophy } from "lucide-react";
+import { Check, Copy, Trophy } from "lucide-react";
 import { UserResult } from "@/types/user-result";
 
 type Props = {
@@ -14,6 +18,7 @@ type Props = {
 };
 
 export function ResultDashboard({ user1, user2 }: Props) {
+  const [copied, setCopied] = useState(false);
   const winner =
     user1.finalScore === user2.finalScore
       ? null
@@ -71,6 +76,31 @@ export function ResultDashboard({ user1, user2 }: Props) {
     Math.max(user1.prScore, user2.prScore) -
     Math.min(user1.prScore, user2.prScore);
 
+  const handleCopy = async () => {
+    const summary = {
+      comparison: {
+        [user1.username]: {
+          finalScore: user1.finalScore,
+          repoScore: user1.repoScore,
+          prScore: user1.prScore,
+          contributionScore: user1.contributionScore,
+        },
+        [user2.username]: {
+          finalScore: user2.finalScore,
+          repoScore: user2.repoScore,
+          prScore: user2.prScore,
+          contributionScore: user2.contributionScore,
+        },
+        winner: winner?.username ?? "tie",
+        leadBy: winner ? `${diffPct}%` : "0%",
+        insights: getInsights(),
+      },
+    };
+    await navigator.clipboard.writeText(JSON.stringify(summary, null, 2));
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
   return (
     <div className="space-y-6 animate-fadeIn">
       <Card className="border-2 border-primary/20 bg-gradient-to-r from-primary/10 via-primary/5 to-transparent">
@@ -103,6 +133,28 @@ export function ResultDashboard({ user1, user2 }: Props) {
           )}
         </CardContent>
       </Card>
+
+      <div className="flex justify-end">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleCopy}
+          className="flex items-center gap-2"
+          aria-label="Copy comparison results to clipboard"
+        >
+          {copied ? (
+            <>
+              <Check className="h-4 w-4 text-green-500" />
+              <span className="text-green-500">Copied!</span>
+            </>
+          ) : (
+            <>
+              <Copy className="h-4 w-4" />
+              Copy Result
+            </>
+          )}
+        </Button>
+      </div>
 
       <div className="grid gap-4 md:grid-cols-4">
         <ScoreCard


### PR DESCRIPTION
## Summary

Implements #35 — adds a **Copy Result** button to the comparison dashboard.

### Changes
- Converts `ResultDashboard` to a client component (`"use client"`)
- Adds a **Copy Result** button (top-right, secondary variant) that copies a structured JSON summary to clipboard
- JSON includes: both developers' scores (`finalScore`, `repoScore`, `prScore`, `contributionScore`), winner, lead percentage, and insights
- Shows **✓ Copied!** (green, with check icon) for 2 seconds after a successful copy, then reverts to the default state
- Accessible: button has an `aria-label` for screen readers

### Before / After
| Before | After |
|--------|-------|
| No way to export results | One-click copy of structured JSON summary |

## Test plan
- [ ] Compare two GitHub users → result dashboard renders
- [ ] Click **Copy Result** → button shows "Copied!" briefly
- [ ] Paste clipboard → valid JSON with both users' scores, winner, and insights