### PR TITLE
feat: add empty state when no comparison is loaded (closes #26)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,6 +93,30 @@ export default function HomePage() {
           </div>
         )}
         {data && <ResultDashboard user1={data.user1} user2={data.user2} />}
+        {!loading && !error && !data && (
+          <div className="flex flex-col items-center justify-center py-20 text-center text-muted-foreground gap-4">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="64"
+              height="64"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="opacity-30"
+            >
+              <circle cx="9" cy="7" r="4" />
+              <circle cx="15" cy="7" r="4" />
+              <path d="M3 21v-2a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4v2" />
+            </svg>
+            <p className="text-lg font-medium">Enter two usernames to compare</p>
+            <p className="text-sm opacity-70">
+              Compare GitHub developer metrics side by side
+            </p>
+          </div>
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary

Closes #26

When no comparison has been loaded yet, the page showed blank space below the form. This PR adds a friendly empty state with:
- An SVG icon showing two user outlines (representing the comparison)  
- A clear message: **"Enter two usernames to compare"**
- A subtitle explaining the feature: "Compare GitHub developer metrics side by side"

The empty state is hidden once loading starts, an error occurs, or comparison data is displayed.

## Changes

- `app/page.tsx`: Added conditional empty state block rendered when `!loading && !error && !data`

## Test plan

- [ ] Load the page fresh — empty state should be visible below the form
- [ ] Enter two usernames and click Compare — empty state disappears during/after loading
- [ ] Clear results with Reset — empty state should reappear