### PR TITLE
feat: display friendly error messages on API failure (closes #34)

### DIFF
--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -36,13 +36,36 @@ export async function GET(request: Request) {
     return NextResponse.json({ success: true, users: results });
   } catch (error: any) {
     console.error("GitHub score error:", error);
-    const message =
-      error?.message === "User not found"
-        ? "GitHub user not found"
-        : "Failed to calculate score";
+
+    let message = "Something went wrong. Please try again later.";
+    let status = 500;
+
+    const msg = error?.message ?? "";
+    if (msg === "User not found") {
+      message =
+        "One or more GitHub users could not be found. Please check the usernames and try again.";
+      status = 404;
+    } else if (
+      msg.includes("rate limit") ||
+      msg.includes("API rate limit") ||
+      error?.status === 403
+    ) {
+      message =
+        "GitHub API rate limit exceeded. Please wait a few minutes and try again.";
+      status = 429;
+    } else if (
+      msg.includes("ENOTFOUND") ||
+      msg.includes("ECONNREFUSED") ||
+      msg.includes("fetch failed")
+    ) {
+      message =
+        "Unable to reach GitHub. Please check your internet connection and try again.";
+      status = 503;
+    }
+
     return NextResponse.json(
       { success: false, error: message },
-      { status: 500 }
+      { status }
     );
   }
 }

--- a/app/api/compare/route.ts
+++ b/app/api/compare/route.ts
@@ -40,22 +40,30 @@ export async function GET(request: Request) {
     let message = "Something went wrong. Please try again later.";
     let status = 500;
 
-    const msg = error?.message ?? "";
-    if (msg === "User not found") {
+    const msg = (error?.message ?? "").toLowerCase();
+    const isNotFound =
+      msg === "user not found" ||
+      msg.includes("could not resolve to a user") ||
+      msg.includes("user not found") ||
+      error?.errors?.some((e: any) =>
+        e?.type === "NOT_FOUND" || e?.message?.toLowerCase().includes("user")
+      );
+
+    if (isNotFound) {
       message =
         "One or more GitHub users could not be found. Please check the usernames and try again.";
       status = 404;
     } else if (
       msg.includes("rate limit") ||
-      msg.includes("API rate limit") ||
+      msg.includes("api rate limit") ||
       error?.status === 403
     ) {
       message =
         "GitHub API rate limit exceeded. Please wait a few minutes and try again.";
       status = 429;
     } else if (
-      msg.includes("ENOTFOUND") ||
-      msg.includes("ECONNREFUSED") ||
+      msg.includes("enotfound") ||
+      msg.includes("econnrefused") ||
       msg.includes("fetch failed")
     ) {
       message =

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,8 +5,6 @@ import { CompareForm } from "../components/compare-form";
 import { ResultDashboard } from "../components/result-dashboard";
 import { DashboardSkeleton } from "../components/skeletons";
 import { UserResult } from "@/types/user-result";
-import { AlertCircle } from "lucide-react";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 type ApiResponse = {
   success: boolean;
@@ -76,7 +74,7 @@ export default function HomePage() {
               DevImpact
             </span>
           </div>
-       
+
         </div>
       </header>
       <div className="max-w-6xl mx-auto px-4 py-10 space-y-6">
@@ -90,13 +88,6 @@ export default function HomePage() {
         />
 
         {loading && skeleton}
-        {error && (
-          <Alert variant="destructive">
-            <AlertCircle className="h-4 w-4" />
-            <AlertTitle>Comparison Failed</AlertTitle>
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
-        )}
         {data && <ResultDashboard user1={data.user1} user2={data.user2} />}
         {!loading && !error && !data && (
           <div className="flex flex-col items-center justify-center py-20 text-center text-muted-foreground gap-4">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,8 @@ import { CompareForm } from "../components/compare-form";
 import { ResultDashboard } from "../components/result-dashboard";
 import { DashboardSkeleton } from "../components/skeletons";
 import { UserResult } from "@/types/user-result";
+import { AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 type ApiResponse = {
   success: boolean;
@@ -84,13 +86,16 @@ export default function HomePage() {
           reset={reset}
           swapUsers={swapUsers}
           data={data}
+          error={error}
         />
 
         {loading && skeleton}
         {error && (
-          <div className="card p-4 text-sm text-red-600 bg-red-50 border border-red-100">
-            {error}
-          </div>
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Comparison Failed</AlertTitle>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
         )}
         {data && <ResultDashboard user1={data.user1} user2={data.user2} />}
         {!loading && !error && !data && (


### PR DESCRIPTION
## Summary
- Improve API error handling to distinguish between user-not-found (404), rate-limit exceeded (429), network errors (503), and generic failures (500)
- Replace plain error `div` with a styled `Alert` component using `AlertCircle` icon and descriptive title
- Pass error prop to `CompareForm` for inline error display near the input fields
- Each error message now includes actionable guidance (e.g., "check usernames", "wait a few minutes")

Closes #34

## Test plan
- [ ] Enter a non-existent GitHub username → should show "could not be found" message with 404
- [ ] Verify error displays with AlertCircle icon and "Comparison Failed" title
- [ ] Verify error clears when submitting a new valid comparison
- [ ] Verify error shows both in form area and below form

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>