### PR TITLE
feat: implement client-side caching for GitHub API responses (closes #33)

### DIFF
--- a/lib/cache.ts
+++ b/lib/cache.ts
@@ -1,0 +1,46 @@
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+class InMemoryCache {
+  private store = new Map<string, CacheEntry<unknown>>();
+
+  set<T>(key: string, data: T, ttlMs: number): void {
+    this.store.set(key, {
+      data,
+      expiresAt: Date.now() + ttlMs,
+    });
+  }
+
+  get<T>(key: string): T | null {
+    const entry = this.store.get(key) as CacheEntry<T> | undefined;
+    if (!entry) return null;
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.data;
+  }
+
+  has(key: string): boolean {
+    return this.get(key) !== null;
+  }
+
+  delete(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+// Singleton cache instance shared across API requests
+export const cache = new InMemoryCache();
+
+export const CACHE_TTL = {
+  ONE_DAY: 24 * 60 * 60 * 1000,
+  ONE_HOUR: 60 * 60 * 1000,
+  FIVE_MINUTES: 5 * 60 * 1000,
+};

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,5 +1,6 @@
 import { ContributionTotals, GitHubUserData, PullRequestNode, RepoNode } from "@/types/github";
 import { graphql } from "@octokit/graphql";
+import { cache, CACHE_TTL } from "./cache";
 
 if (!process.env.GITHUB_TOKEN) {
   throw new Error("Missing GITHUB_TOKEN");
@@ -60,15 +61,26 @@ const QUERY = /* GraphQL */ `
 export async function fetchGitHubUserData(
   username: string
 ): Promise<GitHubUserData> {
+  const cacheKey = `github:user:${username.toLowerCase()}`;
+
+  const cached = cache.get<GitHubUserData>(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const { user } = await client<{ user: any }>(QUERY, { login: username });
 
   if (!user) {
     throw new Error("User not found");
   }
 
-  return {
+  const data: GitHubUserData = {
     repos: user.repositories.nodes as RepoNode[],
     pullRequests: user.pullRequests.nodes as PullRequestNode[],
     contributions: user.contributionsCollection as ContributionTotals,
   };
+
+  cache.set(cacheKey, data, CACHE_TTL.ONE_DAY);
+
+  return data;
 }


### PR DESCRIPTION
## Summary

Implements server-side in-memory caching for GitHub API responses to reduce unnecessary API calls.

### Changes

- **lib/cache.ts** (new): Reusable `InMemoryCache` class with configurable TTL constants (1 day, 1 hour, 5 minutes)
- **lib/github.ts**: Updated `fetchGitHubUserData` to check cache before making API calls; stores result for 1 day

### How it works

1. On each API request, the cache key `github:user:{username}` is checked first
2. If a cached entry exists and hasn't expired, it's returned immediately (no API call)
3. If not cached, the GitHub GraphQL API is called and the result is stored for **1 day**
4. Cache is case-insensitive (username normalized to lowercase)

### Benefits

- Reduces GitHub API calls for repeated lookups of the same user
- Improves response time for cached users
- Helps avoid GitHub API rate limits

Closes #33