### PR TITLE
fix: stick footer to bottom on short pages (closes #58)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,7 +65,7 @@ export default function HomePage() {
     console.log("Swapped users", data);
   };
   return (
-    <main className="min-h-screen">
+    <main className="min-h-screen flex flex-col">
       {" "}
       <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
         <div className="container flex h-16 max-w-7xl items-center justify-between m-auto px-4">
@@ -74,10 +74,10 @@ export default function HomePage() {
               DevImpact
             </span>
           </div>
-       
+
         </div>
       </header>
-      <div className="max-w-6xl mx-auto px-4 py-10 space-y-6">
+      <div className="flex-1 max-w-6xl mx-auto px-4 py-10 space-y-6 w-full">
         <CompareForm
           onSubmit={handleCompare}
           loading={loading}


### PR DESCRIPTION
## Summary

- Add `flex flex-col` to `<main>` so the flex container fills the full viewport height (`min-h-screen`)
- Add `flex-1 w-full` to the main content wrapper div so it grows to push the footer down

This ensures the footer is always pinned to the bottom of the viewport when there is little content, while still scrolling naturally below the content on longer pages.

Closes #58

## Test plan

- [ ] Open the app with no comparison loaded — footer should sit at the very bottom of the viewport
- [ ] Run a comparison — footer should appear below the result cards, scrolling into view normally
- [ ] Resize the browser window to a short height — footer should not overlap content

🤖 Generated with [Claude Code](https://claude.com/claude-code)