### PR TITLE
feat: make pull request titles clickable (closes #61)

### DIFF
--- a/components/top-list.tsx
+++ b/components/top-list.tsx
@@ -27,6 +27,7 @@ type Props = {
 export function TopList({ userResults }: Props) {
   const cardDetails = (data: {
     title: string;
+    url?: string;
     subtitle?: string;
     score?: number;
     badges: { tooltip?: string; label?: any; icon: any }[];
@@ -37,7 +38,15 @@ export function TopList({ userResults }: Props) {
       key={data.key}
     >
       <div>
-        <div className="font-medium text-slate-900">{data.title}</div>
+        <div className="font-medium text-slate-900">
+          {data.url ? (
+            <a href={data.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
+              {data.title}
+            </a>
+          ) : (
+            data.title
+          )}
+        </div>
         <div className="text-xs text-muted-foreground mt-1">
           {data.subtitle}
         </div>
@@ -125,6 +134,7 @@ export function TopList({ userResults }: Props) {
                   cardDetails({
                     key: `pr-${i}`,
                     title: pr.title || "Untitled Pull Request",
+                    url: pr.url,
                     subtitle: `in ${pr.repo}`,
                     score: pr.score,
                     badges: [

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -36,6 +36,8 @@ const QUERY = /* GraphQL */ `
         orderBy: { field: CREATED_AT, direction: DESC }
       ) {
         nodes {
+          title
+          url
           merged
           additions
           deletions

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -89,7 +89,7 @@ export function calculateUserScore(
   contributionScore: number;
   finalScore: number;
   topRepos: { name: string; stars: number; forks: number; score: number }[];
-  topPullRequests: { repo: string; stars: number; score: number }[];
+  topPullRequests: { repo: string; title: string; url: string; stars: number; score: number }[];
 } {
   const repoScore = calculateRepoScore(data.repos);
   const prScore = calculatePRScore(data.pullRequests, username);
@@ -114,7 +114,8 @@ export function calculateUserScore(
     })),
     topPullRequests: prScore.details.slice(0, 3).map((item) => ({
       repo: item.pr.repository.nameWithOwner,
-      title: item.pr.repository.nameWithOwner,
+      title: item.pr.title,
+      url: item.pr.url,
       stars: item.pr.repository.stargazerCount,
       score: item.score,
       additions: item.pr.additions,

--- a/types/github.ts
+++ b/types/github.ts
@@ -7,6 +7,8 @@ export type RepoNode = {
 };
 
 export type PullRequestNode = {
+  title: string;
+  url: string;
   merged: boolean;
   additions: number;
   deletions: number;

--- a/types/user-result.ts
+++ b/types/user-result.ts
@@ -16,6 +16,7 @@ export type UserResult = {
     stars?: number;
     score?: number;
     title?: string;
+    url?: string;
     deletions?: number;
     additions?: number;
   }[];


### PR DESCRIPTION
## Summary
- Add `title` and `url` fields to the GitHub GraphQL `pullRequests` query
- Pass PR URL through the type system (`PullRequestNode` → `UserResult`) and scoring logic
- Wrap PR titles in `<a href={pr.url} target="_blank" rel="noopener noreferrer">` tags in the `TopList` component
- Fix pre-existing bug where PR titles displayed the repository name instead of the actual PR title

Closes #61

## Test plan
- [ ] Verify PR titles in the "Top Pull Requests" section are rendered as clickable links
- [ ] Verify clicking a PR title opens the correct GitHub PR page in a new tab
- [ ] Verify links have `target="_blank"` and `rel="noopener noreferrer"` attributes
- [ ] Verify repository titles (Top Repositories) remain as plain text (no link)
- [ ] Verify PRs without titles gracefully show "Untitled Pull Request"

🤖 Generated with [Claude Code](https://claude.com/claude-code)