### PR TITLE
feat: make pull request titles clickable links to GitHub PR

### DIFF
--- a/components/top-list.tsx
+++ b/components/top-list.tsx
@@ -27,6 +27,7 @@ type Props = {
 export function TopList({ userResults }: Props) {
   const cardDetails = (data: {
     title: string;
+    titleUrl?: string;
     subtitle?: string;
     score?: number;
     badges: { tooltip?: string; label?: any; icon: any }[];
@@ -37,7 +38,20 @@ export function TopList({ userResults }: Props) {
       key={data.key}
     >
       <div>
-        <div className="font-medium text-slate-900">{data.title}</div>
+        <div className="font-medium text-slate-900">
+          {data.titleUrl ? (
+            <a
+              href={data.titleUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline text-primary"
+            >
+              {data.title}
+            </a>
+          ) : (
+            data.title
+          )}
+        </div>
         <div className="text-xs text-muted-foreground mt-1">
           {data.subtitle}
         </div>
@@ -125,6 +139,7 @@ export function TopList({ userResults }: Props) {
                   cardDetails({
                     key: `pr-${i}`,
                     title: pr.title || "Untitled Pull Request",
+                    titleUrl: pr.url,
                     subtitle: `in ${pr.repo}`,
                     score: pr.score,
                     badges: [

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -39,6 +39,8 @@ const QUERY = /* GraphQL */ `
           merged
           additions
           deletions
+          title
+          url
           repository {
             nameWithOwner
             stargazerCount

--- a/lib/score.ts
+++ b/lib/score.ts
@@ -114,7 +114,8 @@ export function calculateUserScore(
     })),
     topPullRequests: prScore.details.slice(0, 3).map((item) => ({
       repo: item.pr.repository.nameWithOwner,
-      title: item.pr.repository.nameWithOwner,
+      title: item.pr.title,
+      url: item.pr.url,
       stars: item.pr.repository.stargazerCount,
       score: item.score,
       additions: item.pr.additions,

--- a/types/github.ts
+++ b/types/github.ts
@@ -10,6 +10,8 @@ export type PullRequestNode = {
   merged: boolean;
   additions: number;
   deletions: number;
+  title: string;
+  url: string;
   repository: {
     nameWithOwner: string;
     stargazerCount: number;

--- a/types/user-result.ts
+++ b/types/user-result.ts
@@ -16,6 +16,7 @@ export type UserResult = {
     stars?: number;
     score?: number;
     title?: string;
+    url?: string;
     deletions?: number;
     additions?: number;
   }[];


### PR DESCRIPTION
closes #61

## Changes

Add clickable links to PR titles in the Top Work section:

- **GraphQL query** (`lib/github.ts`): Add `title` and `url` fields to the pull requests query
- **Type definitions** (`types/github.ts`, `types/user-result.ts`): Add `title` and `url` to `PullRequestNode` and `topPullRequests`
- **Score mapping** (`lib/score.ts`): Use actual PR `title` field (previously was incorrectly using `repository.nameWithOwner`)
- **UI** (`components/top-list.tsx`): Render PR titles as anchor tags opening the PR on GitHub in a new tab

## Before
PR titles were shown as plain text (and the title field was incorrectly using the repo name).

## After
PR titles display actual PR titles as clickable links to the PR on GitHub, opening in a new tab.