### PR TITLE
ui(score-card): remove fraction digits from displayed value

### DIFF
--- a/components/score-card.tsx
+++ b/components/score-card.tsx
@@ -18,7 +18,7 @@ export function ScoreCard({ title, value, highlight, subtitle }: ScoreCardProps)
       <p className="text-xs uppercase tracking-wide text-muted-foreground">{title}</p>
       <div className="flex items-baseline gap-2">
         <span className="text-2xl font-semibold text-foreground">
-          {value.toFixed(2)}
+          {value}
         </span>
         {subtitle && (
           <span className="text-xs text-muted-foreground leading-tight">{subtitle}</span>


### PR DESCRIPTION
Closes #85.

Single-line change at `components/score-card.tsx:21`:

```diff
-          {value.toFixed(2)}
+          {value}
```

Renders whole numbers (and natural float precision for non-integer values) instead of forcing two-decimal display, matching the issue's acceptance task list:

- [x] Open `components/score-card.tsx`
- [x] Locate line 21
- [x] Change `{value.toFixed(2)}` to `{value}`

No other files changed. The component's only consumer of this display is the score card itself, and callers already pass rounded numbers in the common case.