### PR TITLE
fix: remove fraction digits from top-list scores

### DIFF
--- a/components/top-list.tsx
+++ b/components/top-list.tsx
@@ -39,6 +39,7 @@ export function TopList({ userResults }: Props) {
           {data.titleUrl ? (
             <a
               href={data.titleUrl}
+              title="Open on GitHub"
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary hover:underline"
@@ -69,7 +70,7 @@ export function TopList({ userResults }: Props) {
       </div>
       <div className="text-right">
         <p className="text-sm font-semibold text-foreground">
-          {(data.score ?? 0).toFixed(2)}
+          {data.score ?? 0}
         </p>
         <p className="text-[11px] text-muted-foreground">
           {t("comparsion.score")}


### PR DESCRIPTION
Fixes #88

Additionally, at the time of submission of this PR:

- [x] The referred issue is not blocked currently
- [x] All unittests passed after changes were made