### PR TITLE
fix: add tooltips to GitHub links

### DIFF
--- a/components/top-list.tsx
+++ b/components/top-list.tsx
@@ -39,6 +39,7 @@ export function TopList({ userResults }: Props) {
           {data.titleUrl ? (
             <a
               href={data.titleUrl}
+              title="Open on GitHub"
               target="_blank"
               rel="noopener noreferrer"
               className="text-primary hover:underline"


### PR DESCRIPTION
Fixes #78

Additionally, at the time of submission of this PR:

- [x] The referred issue is not blocked currently
- [x] All unittests passed after changes were made