### PR TITLE
feat: always show Swap/Reset buttons and disable when inputs are empty

### DIFF
--- a/components/compare-form.tsx
+++ b/components/compare-form.tsx
@@ -39,6 +39,7 @@ export function CompareForm({
   }, []);
 
   const canSubmit = Boolean(username1.trim() && username2.trim() && !loading);
+  const isEmpty = !username1.trim() && !username2.trim();
 
   const handleSwap = () => {
     setUsername1(username2);
@@ -90,28 +91,24 @@ export function CompareForm({
             >
               {loading ? t("form.compare.ing") : t("form.compare")}
             </Button>
-            {data && (
-              <>
-                <Button
-                  onClick={handleSwap}
-                  disabled={loading}
-                  type="button"
-                  title={t("form.swap")}
-                  className="shadow-sm transition-transform hover:-translate-y-0.5"
-                >
-                  <ArrowLeftRight className="h-4 w-4" />
-                </Button>
-                <Button
-                  onClick={handleReset}
-                  disabled={loading}
-                  title={t("form.reset")}
-                  type="button"
-                  className="shadow-sm transition-transform hover:-translate-y-0.5"
-                >
-                  <RefreshCw className="h-4 w-4" />
-                </Button>
-              </>
-            )}
+            <Button
+              onClick={handleSwap}
+              type="button"
+              disabled={isEmpty || loading}
+              title={t("form.swap")}
+              className="shadow-sm transition-transform hover:-translate-y-0.5"
+            >
+              <ArrowLeftRight className="h-4 w-4" />
+            </Button>
+            <Button
+              onClick={handleReset}
+              title={t("form.reset")}
+              disabled={isEmpty || loading}
+              type="button"
+              className="shadow-sm transition-transform hover:-translate-y-0.5"
+            >
+              <RefreshCw className="h-4 w-4" />
+            </Button>
           </div>
           {error && (
             <Alert variant="destructive" className="mt-4">


### PR DESCRIPTION
Fixes #108

## Summary
This PR improves the UX of the CompareForm by ensuring that the Swap and Reset buttons are always visible, but properly disabled when there is no input data.

<img width="1504" height="870" alt="image" src="https://github.com/user-attachments/assets/6974a6b5-ad4b-446a-af53-8f26316793fd" />


## Changes
- Always render Swap and Reset buttons (removed conditional rendering)
- Add disabled state based on input values and loading state
- Improve UX consistency between Submit, Swap, and Reset actions
- Prevent actions when both input fields are empty or when loading

## Logic Update
- Buttons are disabled when:
  - Both username fields are empty
  - OR the form is in loading state

## UX Improvement
- Prevents layout shifting caused by conditional rendering
- Improves discoverability of available actions
- Keeps UI consistent and predictable

## Checklist
- [x] Buttons always visible
- [x] Disabled state implemented correctly
- [x] No breaking changes
