### PR TITLE
feat: sync route params with compare form inputs

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { Suspense, useEffect, useEffectEvent, useMemo, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { CompareForm } from "../components/compare-form";
 import { ResultDashboard } from "../components/result-dashboard";
 import { DashboardSkeleton } from "../components/skeletons";
@@ -16,14 +17,24 @@ type ApiResponse = {
   error?: string;
 };
 
-export default function HomePage() {
+function HomePageInner() {
   const { t } = useTranslation();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initialUsernames = searchParams.getAll("username");
+  const initialUsername1 = initialUsernames[0] ?? "";
+  const initialUsername2 = initialUsernames[1] ?? "";
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [username1, setUsername1] = useState(initialUsername1);
+  const [username2, setUsername2] = useState(initialUsername2);
   const [data, setData] = useState<{
     user1: UserResult;
     user2: UserResult;
   } | null>(null);
+  // Track the URL pair we last fetched against so back/forward navigation
+  // can resync the form and results without re-fetching identical pairs.
+  const lastFetchedPairRef = useRef<[string, string] | null>(null);
 
   const localizeErrorMessage = (message?: string) => {
     switch (message) {
@@ -43,6 +54,11 @@ export default function HomePage() {
   };
 
   const handleCompare = async (u1: string, u2: string) => {
+    lastFetchedPairRef.current = [u1, u2];
+    router.push(
+      `/?username=${encodeURIComponent(u1)}&username=${encodeURIComponent(u2)}`,
+      { scroll: false }
+    );
     setLoading(true);
     setError(null);
     setData(null);
@@ -79,14 +95,56 @@ export default function HomePage() {
     }
   };
 
+  // Resync form + results to whatever the URL says — handles initial mount
+  // AND back/forward navigation. We fetch only when the URL pair differs from
+  // the last pair we fetched, so no infinite loop with the router.push above.
+  const syncToUrl = useEffectEvent((u1: string, u2: string) => {
+    setUsername1(u1);
+    setUsername2(u2);
+
+    if (!u1 || !u2) {
+      // Empty params: clear results so the empty state matches the URL.
+      lastFetchedPairRef.current = null;
+      setData(null);
+      setError(null);
+      return;
+    }
+
+    const last = lastFetchedPairRef.current;
+    if (last && last[0] === u1 && last[1] === u2) {
+      // URL already reflects the most recent fetch; nothing to do.
+      return;
+    }
+
+    void handleCompare(u1, u2);
+  });
+
+  useEffect(() => {
+    const params = searchParams.getAll("username");
+    syncToUrl(params[0] ?? "", params[1] ?? "");
+  }, [searchParams]);
+
   const skeleton = useMemo(() => <DashboardSkeleton />, []);
 
   const reset = () => {
     setData(null);
     setError(null);
+    setUsername1("");
+    setUsername2("");
+    router.push("/", { scroll: false });
   };
 
   const swapUsers = () => {
+    const nextUsername1 = username2;
+    const nextUsername2 = username1;
+
+    setUsername1(nextUsername1);
+    setUsername2(nextUsername2);
+    router.push(
+      `/?username=${encodeURIComponent(nextUsername1)}&username=${encodeURIComponent(nextUsername2)}`,
+      { scroll: false }
+    );
+
     if (!data) return;
     setData((d) => ({ user1: d!.user2, user2: d!.user1 }));
   };
@@ -97,6 +155,10 @@ export default function HomePage() {
 
       <div className="w-full flex-1 max-w-6xl mx-auto px-4 py-10 space-y-6">
         <CompareForm
+          username1={username1}
+          username2={username2}
+          setUsername1={setUsername1}
+          setUsername2={setUsername2}
           onSubmit={handleCompare}
           loading={loading}
           reset={reset}
@@ -124,5 +186,13 @@ export default function HomePage() {
 
       <AppFooter />
     </main>
+  );
+}
+
+export default function HomePage() {
+  return (
+    <Suspense fallback={<DashboardSkeleton />}>
+      <HomePageInner />
+    </Suspense>
   );
 }

--- a/components/compare-form.tsx
+++ b/components/compare-form.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useRef, useEffect } from "react";
 import { Button } from "./ui/button";
 import { ArrowLeftRight, RefreshCw } from "lucide-react";
 import {
@@ -12,6 +12,10 @@ import { Alert, AlertDescription } from "./ui/alert";
 import { useTranslation } from "./language-provider";
 
 type CompareFormProps = {
+  username1: string;
+  username2: string;
+  setUsername1: (value: string) => void;
+  setUsername2: (value: string) => void;
   data?: boolean;
   onSubmit: (u1: string, u2: string) => void;
   loading?: boolean;
@@ -21,16 +25,17 @@ type CompareFormProps = {
 };
 
 export function CompareForm({
+  username1,
+  username2,
+  setUsername1,
+  setUsername2,
   onSubmit,
-  data,
   loading,
   swapUsers,
   reset,
   error,
 }: CompareFormProps) {
   const { t } = useTranslation();
-  const [username1, setUsername1] = useState("pbiggar");
-  const [username2, setUsername2] = useState("CoralineAda");
   const firstInputRef = useRef<HTMLInputElement>(null);
 
   // Auto-focus first input on page load
@@ -42,14 +47,10 @@ export function CompareForm({
   const isEmpty = !username1.trim() && !username2.trim();
 
   const handleSwap = () => {
-    setUsername1(username2);
-    setUsername2(username1);
     if (swapUsers) swapUsers();
   };
 
   const handleReset = () => {
-    setUsername1("");
-    setUsername2("");
     if (reset) reset();
   };
 


### PR DESCRIPTION
## Summary

Closes #21. The home page now treats `?username=u1&username=u2` as the source of truth for the compare form and results:

- Mount with URL params populates the inputs and auto-loads the comparison.
- Submitting the form pushes the URL via `router.push` so the result is shareable / copy-pasteable.
- Back/forward buttons resync the form and re-fetch as needed.
- `swap` and `reset` push their corresponding URL state too.

## Why this matters

The form was previously seeded with hardcoded `pbiggar` / `CoralineAda` defaults and the URL never reflected what was being compared, so a user couldn't share or bookmark a result. The issue's two main tasks (`update the url params when the form values change` + `when the page initialize check the url params to update the form values and fetching the required data`) both land here.

The implementation lifts username state out of `CompareForm` into `app/page.tsx` so the URL can drive both. The form becomes controlled — it accepts `username1` / `username2` / `setUsername1` / `setUsername2` props from the page and no longer owns local input state.

A `useEffect` watching `searchParams` calls into a `useEffectEvent`-wrapped `syncToUrl` helper. `syncToUrl` is the single resync entry point used for initial mount AND back/forward navigation; it short-circuits via `lastFetchedPairRef` so our own `router.push` calls don't trigger duplicate fetches.

## Changes

- `app/page.tsx`:
  - Wrapped the body in `<Suspense>` (required by `useSearchParams`) and split the body into a `HomePageInner` component.
  - Added `useRouter` + `useSearchParams` to read the URL.
  - Lifted `username1` / `username2` state from the form into the page; seeded from URL params.
  - `handleCompare` now `router.push`es the URL before fetching, and stamps `lastFetchedPairRef`.
  - `swapUsers` and `reset` push the corresponding URL state.
  - New `searchParams`-watching `useEffect` + `useEffectEvent` resyncs form/results on URL change.
- `components/compare-form.tsx`:
  - Accepts `username1` / `username2` / `setUsername1` / `setUsername2` props.
  - Removed local `useState` and the hardcoded `pbiggar` / `CoralineAda` defaults.
  - `handleSwap` / `handleReset` keep their existing parent-callback shape.

## Testing

- `pnpm run build` — `Compiled successfully` and `Finished TypeScript` both pass on this diff. The build then fails at `Collecting page data` with `Missing GITHUB_TOKEN`, but that's a pre-existing failure of the `/api/compare` route in any local build without a token, not anything this PR introduced.
- `pnpm run lint` — same 5 pre-existing issues (3 errors / 2 warnings) reported on `master`. None in `app/page.tsx` or `components/compare-form.tsx`.

Manual verification flow:

1. Visit `/` — empty form, empty state.
2. Compare two users — inputs filled, URL becomes `/?username=u1&username=u2`, results load.
3. Copy that URL into a new tab — same comparison auto-loads.
4. Change usernames + submit again — URL updates, results update.
5. Hit Back — URL reverts and the form/results follow it.

This contribution was developed with AI assistance (Codex).
