### PR TITLE
refactor: move ApiResponse type to a dedicated file

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,12 +10,7 @@ import { BrandLogo } from "@/components/brand-logo";
 import { AppHeader } from "@/components/app-header";
 import { AppFooter } from "@/components/app-footer";
 import { useTranslation } from "@/components/language-provider";
-
-type ApiResponse = {
-  success: boolean;
-  users?: UserResult[];
-  error?: string;
-};
+import { ApiResponse } from "@/types/api-response";
 
 function HomePageInner() {
   const { t } = useTranslation();

--- a/types/api-response.ts
+++ b/types/api-response.ts
@@ -1,0 +1,7 @@
+import { UserResult } from "./user-result";
+
+export type ApiResponse = {
+  success: boolean;
+  users?: UserResult[];
+  error?: string;
+};


### PR DESCRIPTION
## Description of Changes
The `ApiResponse` type was previously defined locally within `app/page.tsx`. This refactor moves the type
definition to `types/api-response.ts`, enabling it to be shared across the frontend and API routes. This
change improves modularity and prevents code duplication, adhering to the project's coding standards.

Fixes #137

Additionally, at the time of submission of this PR:

- [x] The referred issue is not blocked currently
- [x] All unittests passed after changes were made
