### PR TITLE
fix(ui): make BreakdownBars respect page direction (RTL/LTR)

### DIFF
--- a/components/breakdown-bars.tsx
+++ b/components/breakdown-bars.tsx
@@ -20,7 +20,7 @@ export function BreakdownBars({ user1, user2 }: Props) {
   const { t,dir } = useTranslation();
 
   return (
-    <Card>
+    <Card dir={dir}>
       <CardHeader>
         <CardTitle>{t('breakdown.title')}</CardTitle>
         <CardDescription>


### PR DESCRIPTION
Closes #129.

`components/breakdown-bars.tsx` already destructures `dir` from `useTranslation()` but never threads it onto the rendered DOM, so the breakdown card stayed LTR even when an RTL locale (Arabic) was active. This adds `dir={dir}` to the root `<Card>`, matching the pattern already used in `components/comparison-chart.tsx:77` and `components/language-switcher.tsx:44`.

One-line diff; no other functional change. `tsc --noEmit` passes locally.