### PR TITLE
[Docs] Add AI-generated content policy to Contribution Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,16 +123,6 @@ Use descriptive commit messages with a prefix:
 - `style:` for formatting changes (no logic change)
 - `test:` for adding or updating tests
 
-## AI-Generated Content Policy
-
-We welcome contributions assisted by AI tools (GitHub Copilot, ChatGPT, Claude, etc.). To maintain quality and reliability:
-
-1. **Disclose AI assistance**: If AI tools were used to generate a significant portion of your contribution, mention it in your PR description.
-2. **Review before submitting**: Always review AI-generated content for accuracy, relevance, and adherence to our coding standards before submitting.
-3. **No bulk AI submissions**: Do not submit large batches of AI-generated code without thorough review. Each PR should represent thoughtful, intentional work.
-4. **Originality**: Ensure your contribution does not reproduce copyrighted material from AI training data.
-5. **Accountability**: You are responsible for the quality and correctness of all content in your PRs, regardless of how it was generated.
-
 ## Pull Request Guidelines
 
 - Reference the related issue using `Fixes #<issue_number>` in the PR description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,16 @@ Use descriptive commit messages with a prefix:
 - `style:` for formatting changes (no logic change)
 - `test:` for adding or updating tests
 
+## AI-Generated Content Policy
+
+We welcome contributions assisted by AI tools (GitHub Copilot, ChatGPT, Claude, etc.). To maintain quality and reliability:
+
+1. **Disclose AI assistance**: If AI tools were used to generate a significant portion of your contribution, mention it in your PR description.
+2. **Review before submitting**: Always review AI-generated content for accuracy, relevance, and adherence to our coding standards before submitting.
+3. **No bulk AI submissions**: Do not submit large batches of AI-generated code without thorough review. Each PR should represent thoughtful, intentional work.
+4. **Originality**: Ensure your contribution does not reproduce copyrighted material from AI training data.
+5. **Accountability**: You are responsible for the quality and correctness of all content in your PRs, regardless of how it was generated.
+
 ## Pull Request Guidelines
 
 - Reference the related issue using `Fixes #<issue_number>` in the PR description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,11 @@
+**⚠️ Important Note on AI-Generated Contributions**
+
+While we appreciate the use of AI as a productivity tool, pull requests consisting of code or documentation generated entirely by AI **without significant human review and testing** are not welcome.
+
+Every contributor is responsible for the code they submit. If we suspect a contribution is a "blind" AI generation that has not been verified for logic, security, or style, it will be closed without review.
+
+---
+
 # Contributing to DevImpact
 
 Thank you for your interest in contributing to DevImpact! This guide will help you get started.


### PR DESCRIPTION
## Summary

Adds an AI-Generated Content Policy section to CONTRIBUTING.md, as requested in O2sa/DevImpact#146.

## Changes

- Added `## AI-Generated Content Policy` section before `## Pull Request Guidelines`
- Covers: disclosure requirement, review before submitting, no bulk AI submissions, originality, and accountability

Closes O2sa/DevImpact#146