### PR TITLE
refac: Move GithubLink from ThemeToggle to AppHeader

### DIFF
--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { BrandLogo } from "@/components/brand-logo";
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { GithubLink } from "@/components/github-link";
 
 export function AppHeader() {
   return (
@@ -11,9 +12,10 @@ export function AppHeader() {
           <BrandLogo priority size="md" />
         </Link>
 
-        <div className="flex gap-4">
+        <div className="flex gap-4 [&>*:last-child]:-ml-4">
           <LanguageSwitcher />
           <ThemeToggle />
+          <GithubLink variant="compact" />
         </div>
       </div>
     </header>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -5,7 +5,6 @@ import { useTheme } from "next-themes";
 import { useSyncExternalStore } from "react";
 import { useTranslation } from "./language-provider";
 import { Button } from "./ui/button";
-import { GithubLink } from "./github-link";
 
 const emptySubscribe = () => () => { };
 
@@ -81,7 +80,6 @@ export function ThemeToggle() {
       >
         {mounted && current === "dark" ? <Sun size={16} /> : <Moon size={16} />}
       </Button>
-      <GithubLink variant="compact" />
     </div>
   );
 }


### PR DESCRIPTION
Fixes #158 

This PR moves the compact `GithubLink` from `ThemeToggle` to `AppHeader` so the link is owned by the header layout, while keeping the header actions aligned with a small spacing adjustment.

Additionally, at the time of submission of this PR:

- The referred issue is not blocked currently
- All unittests passed after changes were made
