### PR TITLE
feat: make GitHub repository URL configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 GITHUB_TOKEN=your_github_token_here
+# Public GitHub repository URL shown by the app.
+# If omitted, the app falls back to https://github.com/O2sa/DevImpact
+NEXT_PUBLIC_GITHUB_REPO_URL=your_github_repo_url_here
 
 # Redis caching (optional)
 # Use either redis://localhost:6379 or include password if enabled: redis://:password@localhost:6379

--- a/components/github-link.tsx
+++ b/components/github-link.tsx
@@ -11,9 +11,10 @@ type GithubLinkProps = {
 export function GithubLink({ variant = "compact" }: GithubLinkProps) {
   const isProminent = variant === "prominent";
 
+  const githubRepoUrl= process.env.NEXT_PUBLIC_GITHUB_REPO_URL || "https://github.com/O2sa/DevImpact";
   return (
     <a
-      href="https://github.com/O2sa/DevImpact"
+      href={githubRepoUrl}
       target="_blank"
       rel="noopener noreferrer"
       aria-label="GitHub repository"


### PR DESCRIPTION
## Summary

- Read the GitHub repository URL from `NEXT_PUBLIC_GITHUB_REPO_URL`
- Fall back to `https://github.com/O2sa/DevImpact` when the variable is not set
- Document the new environment variable in `.env.example`

## Testing

- Verified the link opens the default repository when the environment variable is unset.
- Verified the link opens the configured repository URL when `NEXT_PUBLIC_GITHUB_REPO_URL` is set.


close #162 