### PR TITLE
feat: add locale keys validation script (#166)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "vitest",
     "test:watch": "vitest --watch",
     "redis:up": "docker compose up -d redis",
-    "redis:down": "docker compose stop redis"
+    "redis:down": "docker compose stop redis",
+    "validate-locales": "node scripts/validate-locales.js"
   },
   "dependencies": {
     "@octokit/graphql": "^9.0.3",

--- a/scripts/validate-locales.js
+++ b/scripts/validate-locales.js
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
 const fs = require('fs');
 const path = require('path');
 

--- a/scripts/validate-locales.js
+++ b/scripts/validate-locales.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const localesDir = path.join(__dirname, '..', 'locales');
+const enKeys = Object.keys(JSON.parse(fs.readFileSync(path.join(localesDir, 'en.json'), 'utf8'))).sort();
+
+let hasError = false;
+
+fs.readdirSync(localesDir).forEach(file => {
+  if (file === 'en.json') return;
+
+  const fileKeys = Object.keys(JSON.parse(fs.readFileSync(path.join(localesDir, file), 'utf8'))).sort();
+  const missing = enKeys.filter(k => !fileKeys.includes(k));
+  const extra = fileKeys.filter(k => !enKeys.includes(k));
+  if (missing.length || extra.length) {
+    hasError = true;
+    console.error(`${file}: ${missing.length ? `Missing keys: ${missing.join(', ')}` : ''}${extra.length ? ` Extra keys: ${extra.join(', ')}` : ''}`);
+  }
+});
+
+process.exit(hasError ? 1 : 0);


### PR DESCRIPTION
### Overview 
- added i18n validation script as `scripts/validate-locales.js`
- its script is added to `package.json`
- to run the script insurt `node scripts/validate-locales.js` in the terminal 
- if it returns nothing that means all the keys are compatible 
---
Closes #166 